### PR TITLE
Add option `--context` to dbmigrator in order to load entry points

### DIFF
--- a/dbmigrator/cli.py
+++ b/dbmigrator/cli.py
@@ -28,6 +28,10 @@ def main(argv=sys.argv[1:]):
     parser.add_argument('--db-connection-string',
                         help='a psycopg2 db connection string')
 
+    parser.add_argument(
+        '--context',
+        help='Name of the python package containing the migrations')
+
     subparsers = parser.add_subparsers(help='commands')
     commands.load_cli(subparsers)
 
@@ -41,7 +45,13 @@ def main(argv=sys.argv[1:]):
             'migrations-directory',
             'db-connection-string',
             ], args)
-    utils.get_settings_from_entry_points(args)
+
+    if not args.get('context'):
+        args['context'] = os.path.basename(os.path.abspath(os.path.curdir))
+        print('context undefined, using current directory name "{}"'
+              .format(args['context']),
+              file=sys.stderr)
+    utils.get_settings_from_entry_points(args, args['context'])
 
     for name, value in DEFAULTS.items():
         if not args.get(name):

--- a/dbmigrator/cli.py
+++ b/dbmigrator/cli.py
@@ -34,7 +34,9 @@ def main(argv=sys.argv[1:]):
     args = parser.parse_args(argv)
     args = vars(args)
 
-    if args.get('config') and os.path.exists(args['config']):
+    if args.get('config'):
+        if not os.path.exists(args['config']):
+            raise Exception('config file not found')
         utils.get_settings_from_config(args['config'], [
             'migrations-directory',
             'db-connection-string',

--- a/dbmigrator/utils.py
+++ b/dbmigrator/utils.py
@@ -22,8 +22,10 @@ import sys
 import subprocess
 
 
-def get_settings_from_entry_points(settings):
-    for entry_point in pkg_resources.iter_entry_points(group=__package__):
+def get_settings_from_entry_points(settings, context):
+    entry_points = pkg_resources.get_entry_map(
+        context, __package__).values()
+    for entry_point in entry_points:
         setting_name = entry_point.name
         if settings.get(setting_name):
             # don't overwrite settings given from the CLI


### PR DESCRIPTION
If context is not defined, the current working directory name is used.

Close #6 