### PR TITLE
Allow multiple migrations directories / context to be specified

### DIFF
--- a/dbmigrator/cli.py
+++ b/dbmigrator/cli.py
@@ -22,6 +22,8 @@ DEFAULTS = {
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(description='DB Migrator')
 
+    parser.add_argument('--verbose', '-v', action='store_true')
+
     parser.add_argument('--migrations-directory',
                         default='')
 
@@ -74,5 +76,8 @@ def main(argv=sys.argv[1:]):
             args['migrations_directory'])
     else:
         print('migrations directory undefined', file=sys.stderr)
+
+    if args.get('verbose'):
+        print('args: {}'.format(args))
 
     return args['cmmd'](**args)

--- a/dbmigrator/cli.py
+++ b/dbmigrator/cli.py
@@ -25,7 +25,8 @@ def main(argv=sys.argv[1:]):
     parser.add_argument('--verbose', '-v', action='store_true')
 
     parser.add_argument('--migrations-directory',
-                        default='')
+                        action='append',
+                        default=[])
 
     parser.add_argument('--config')
 
@@ -34,6 +35,8 @@ def main(argv=sys.argv[1:]):
 
     parser.add_argument(
         '--context',
+        action='append',
+        default=[],
         help='Name of the python package containing the migrations')
 
     parser.add_argument('--version', action='store_true')
@@ -56,7 +59,7 @@ def main(argv=sys.argv[1:]):
             'db-connection-string',
             ], args)
 
-    if not args.get('context'):
+    if not args.get('context') and not args.get('migrations_directory'):
         args['context'] = os.path.basename(os.path.abspath(os.path.curdir))
         print('context undefined, using current directory name "{}"'
               .format(args['context']),
@@ -72,8 +75,10 @@ def main(argv=sys.argv[1:]):
         return parser.error('command missing')
 
     if args.get('migrations_directory'):
-        args['migrations_directory'] = os.path.relpath(
-            args['migrations_directory'])
+        if not isinstance(args['migrations_directory'], list):
+            args['migrations_directory'] = [args['migrations_directory']]
+        args['migrations_directory'] = [
+            os.path.relpath(md) for md in args['migrations_directory']]
     else:
         print('migrations directory undefined', file=sys.stderr)
 

--- a/dbmigrator/commands/generate.py
+++ b/dbmigrator/commands/generate.py
@@ -19,6 +19,8 @@ def cli_command(migration_name='', **kwargs):
     directory = kwargs['migrations_directory']
     if not directory:
         raise Exception('migrations directory undefined')
+    if len(directory) > 1:
+        raise Exception('more than one migrations directory specified')
     path = os.path.join(directory, filename)
     if not os.path.isdir(directory):
         os.makedirs(directory)


### PR DESCRIPTION
`generate` raises an error if more than one migrations directory is
specified.

This fixes the problem of multiple migrations directories being used for
the same schema_migrations table.