### PR TITLE
Fix default context (working directory) being a string instead of a list

### DIFF
--- a/dbmigrator/cli.py
+++ b/dbmigrator/cli.py
@@ -57,7 +57,7 @@ def main(argv=sys.argv[1:]):
             ], args)
 
     if not args.get('context') and not args.get('migrations_directory'):
-        args['context'] = os.path.basename(os.path.abspath(os.path.curdir))
+        args['context'] = [os.path.basename(os.path.abspath(os.path.curdir))]
         print('context undefined, using current directory name "{}"'
               .format(args['context']),
               file=sys.stderr)


### PR DESCRIPTION
utils.get_settings_from_entry_points expects a list.

Oops :expressionless: 
I'll be writing more tests