### PR TITLE
Change version information option to "-V"

### DIFF
--- a/dbmigrator/cli.py
+++ b/dbmigrator/cli.py
@@ -40,7 +40,8 @@ def main(argv=sys.argv[1:]):
         help='Name of the python package containing the migrations')
 
     version = pkg_resources.require('db-migrator')[0].version
-    parser.add_argument('--version', action='version', version=version)
+    parser.add_argument('-V', action='version', version=version,
+                        help='Show version information')
 
     subparsers = parser.add_subparsers(help='commands')
     commands.load_cli(subparsers)

--- a/dbmigrator/tests/test_cli.py
+++ b/dbmigrator/tests/test_cli.py
@@ -20,7 +20,7 @@ class MainTestCase(unittest.TestCase):
 
         version = pkg_resources.get_distribution('db-migrator').version
         with captured_output() as (out, err):
-            self.assertRaises(SystemExit, main, ['--version'])
+            self.assertRaises(SystemExit, main, ['-V'])
 
         stdout = out.getvalue()
         stderr = err.getvalue()


### PR DESCRIPTION
Avoid option conflict with `dbmigrator migrate --version` and
`dbmigrator init --version`.

Close #16