### PR TITLE
Add a logger for dbmigrator that writes to stdout

### DIFF
--- a/dbmigrator/__init__.py
+++ b/dbmigrator/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+import logging
+import sys
+
+logger = logging.getLogger('dbmigrator')
+logger.setLevel(logging.INFO)
+
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(logging.Formatter('[%(levelname)s] %(name)s (%(filename)s) - %(message)s'))
+logger.addHandler(handler)


### PR DESCRIPTION
For example in a migration file
20160128111115_mimetype_removal_from_module_files.py:

```
from dbmigrator import logger

logger.info('message from migration')
```

You will see this when you run the migration:

```
[INFO] dbmigrator (20160128111115_mimetype_removal_from_module_files.py) - message from migration
```

Close #3