### PR TITLE
Log warning message for "list" if schema_migrations table doesn't exist

### DIFF
--- a/dbmigrator/commands/list.py
+++ b/dbmigrator/commands/list.py
@@ -16,7 +16,8 @@ __all__ = ('cli_loader',)
 def cli_command(cursor, migrations_directory='', db_connection_string='',
                 **kwargs):
     migrated_versions = dict(list(
-        utils.get_schema_versions(cursor, versions_only=False)))
+        utils.get_schema_versions(cursor, versions_only=False,
+                                  raise_error=False)))
     migrations = utils.get_migrations(migrations_directory)
 
     print('{:<25} | is applied | date applied'.format('name'))

--- a/dbmigrator/utils.py
+++ b/dbmigrator/utils.py
@@ -22,6 +22,8 @@ import re
 import sys
 import subprocess
 
+from . import logger
+
 
 def get_settings_from_entry_points(settings, contexts):
     context_settings = {}
@@ -108,13 +110,20 @@ def get_migrations(migration_directories, import_modules=False, reverse=False):
                 yield version, migration_name
 
 
-def get_schema_versions(cursor, versions_only=True):
-    cursor.execute('SELECT * FROM schema_migrations ORDER BY version')
-    for i in cursor.fetchall():
-        if versions_only:
-            yield i[0]
-        else:
-            yield i
+def get_schema_versions(cursor, versions_only=True, raise_error=True):
+    try:
+        cursor.execute('SELECT * FROM schema_migrations ORDER BY version')
+        for i in cursor.fetchall():
+            if versions_only:
+                yield i[0]
+            else:
+                yield i
+    except psycopg2.ProgrammingError as e:
+        if raise_error:
+            raise
+        logger.warn(str(e))
+        logger.warn('You may need to run "dbmigrator init" to create the '
+                    'schema_migrations table')
 
 
 def get_pending_migrations(migration_directories, cursor, import_modules=False,


### PR DESCRIPTION
For "list", we'll output a warning message showing the error from
postgres, and continue with the listing of migrations.

For "migrate" and "rollback", we want to make sure schema_migrations
exist and error before running the migrations.

Slightly modified version of #17.