### PR TITLE
Add integration test settings and tests for utils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,11 @@ before_install:
   # Install the coverage utility and coveralls reporting utility
   - pip install coverage
   - pip install coveralls
+  - pip install pep8
 install:
   - pip install .
+before_script:
+  - pep8 dbmigrator
 script:
   # This is the same as `python setup.py test` with a coverage wrapper.
   - coverage run --source=dbmigrator setup.py test

--- a/dbmigrator/__init__.py
+++ b/dbmigrator/__init__.py
@@ -7,5 +7,6 @@ logger = logging.getLogger('dbmigrator')
 logger.setLevel(logging.INFO)
 
 handler = logging.StreamHandler(sys.stdout)
-handler.setFormatter(logging.Formatter('[%(levelname)s] %(name)s (%(filename)s) - %(message)s'))
+handler.setFormatter(logging.Formatter(
+    '[%(levelname)s] %(name)s (%(filename)s) - %(message)s'))
 logger.addHandler(handler)

--- a/dbmigrator/commands/generate.py
+++ b/dbmigrator/commands/generate.py
@@ -21,6 +21,7 @@ def cli_command(migration_name='', **kwargs):
         raise Exception('migrations directory undefined')
     if len(directory) > 1:
         raise Exception('more than one migrations directory specified')
+    directory = directory[0]
     path = os.path.join(directory, filename)
     if not os.path.isdir(directory):
         os.makedirs(directory)

--- a/dbmigrator/commands/generate.py
+++ b/dbmigrator/commands/generate.py
@@ -29,6 +29,7 @@ def cli_command(migration_name='', **kwargs):
         f.write("""\
 # -*- coding: utf-8 -*-
 
+
 def up(cursor):
     # TODO migration code
     pass

--- a/dbmigrator/tests/data/config.ini
+++ b/dbmigrator/tests/data/config.ini
@@ -1,0 +1,7 @@
+[section:name]
+db-connection-string = dbname=people user=test host=db.example.org
+migrations-directory = /var/lib/my-package/migrations
+some-other-setting = yes
+
+[other:section]
+port = 8888

--- a/dbmigrator/tests/data/package-a/package_a/__init__.py
+++ b/dbmigrator/tests/data/package-a/package_a/__init__.py
@@ -5,3 +5,14 @@
 # Public License version 3 (AGPLv3).
 # See LICENCE.txt for details.
 # ###
+
+import os.path
+
+
+def hello():
+    print('hello world!')
+
+
+def migrations_directory():
+    here = os.path.abspath(os.path.dirname(__file__))
+    return os.path.join(here, 'migrations')

--- a/dbmigrator/tests/data/package-a/package_a/migrations/20160228202637_add_table.py
+++ b/dbmigrator/tests/data/package-a/package_a/migrations/20160228202637_add_table.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+
+def up(cursor):
+    cursor.execute('CREATE TABLE a_table (name text)')
+
+
+def down(cursor):
+    cursor.execute('DROP TABLE a_table')

--- a/dbmigrator/tests/data/package-a/package_a/migrations/20160228212456_cool_stuff.py
+++ b/dbmigrator/tests/data/package-a/package_a/migrations/20160228212456_cool_stuff.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+
+def up(cursor):
+    # TODO migration code
+    pass
+
+
+def down(cursor):
+    # TODO rollback code
+    pass

--- a/dbmigrator/tests/data/package-a/setup.py
+++ b/dbmigrator/tests/data/package-a/setup.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# ###
+# Copyright (c) 2016, Rice University
+# This software is subject to the provisions of the GNU Affero General
+# Public License version 3 (AGPLv3).
+# See LICENCE.txt for details.
+# ###
+
+from setuptools import setup, find_packages
+
+setup(
+    name='package-a',
+    version='1.2.3',
+    packages=find_packages(),
+    entry_points={
+        'console_scripts': [
+            'package_a_hello = package_a.hello',
+            ],
+        'dbmigrator': [
+            'migrations_directory = package_a:migrations_directory',
+            ],
+        },
+    )

--- a/dbmigrator/tests/data/package-b/package_b/__init__.py
+++ b/dbmigrator/tests/data/package-b/package_b/__init__.py
@@ -5,3 +5,9 @@
 # Public License version 3 (AGPLv3).
 # See LICENCE.txt for details.
 # ###
+
+import os.path
+
+
+here = os.path.abspath(os.path.dirname(__file__))
+find_migrations_directory = os.path.join(here, 'm')

--- a/dbmigrator/tests/data/package-b/package_b/m/20160228210326_initial_data.py
+++ b/dbmigrator/tests/data/package-b/package_b/m/20160228210326_initial_data.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+
+def up(cursor):
+    # TODO migration code
+    pass
+
+
+def down(cursor):
+    # TODO rollback code
+    pass

--- a/dbmigrator/tests/data/package-b/setup.py
+++ b/dbmigrator/tests/data/package-b/setup.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# ###
+# Copyright (c) 2016, Rice University
+# This software is subject to the provisions of the GNU Affero General
+# Public License version 3 (AGPLv3).
+# See LICENCE.txt for details.
+# ###
+
+from setuptools import setup, find_packages
+
+setup(
+    name='package-b',
+    version='10.20.30',
+    packages=find_packages(),
+    entry_points={
+        'dbmigrator': [
+            'migrations_directory = package_b:find_migrations_directory',
+            ],
+        },
+    )

--- a/dbmigrator/tests/test_utils.py
+++ b/dbmigrator/tests/test_utils.py
@@ -120,3 +120,14 @@ class UtilsTestCase(unittest.TestCase):
                               'the migration is rolled back')
                 except psycopg2.ProgrammingError as e:
                     self.assertIn('relation "a_table" does not exist', str(e))
+
+    def test_get_migrations(self):
+        from ..utils import get_migrations
+
+        migrations = get_migrations(testing.test_migrations_directories)
+
+        self.assertEqual(
+            list(migrations),
+            [('20160228202637', 'add_table'),
+             ('20160228210326', 'initial_data'),
+             ('20160228212456', 'cool_stuff')])

--- a/dbmigrator/tests/test_utils.py
+++ b/dbmigrator/tests/test_utils.py
@@ -30,3 +30,21 @@ class UtilsTestCase(unittest.TestCase):
             {'migrations_directory': testing.test_migrations_directories,
              'db_connection_string': testing.db_connection_string,
              })
+
+    def test_get_settings_from_config(self):
+        from ..utils import get_settings_from_config
+
+        settings = {
+            'migrations_directory': '/tmp/',
+            }
+
+        get_settings_from_config(
+            testing.test_config_path,
+            ['db-connection-string', 'migrations-directory', 'does-not-exist'],
+            settings)
+
+        self.assertEqual(
+            settings,
+            {'db_connection_string':
+                'dbname=people user=test host=db.example.org',
+             'migrations_directory': '/tmp/'})

--- a/dbmigrator/tests/test_utils.py
+++ b/dbmigrator/tests/test_utils.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# ###
+# Copyright (c) 2016, Rice University
+# This software is subject to the provisions of the GNU Affero General
+# Public License version 3 (AGPLv3).
+# See LICENCE.txt for details.
+# ###
+
+import os.path
+import unittest
+
+from . import testing
+
+
+class UtilsTestCase(unittest.TestCase):
+    def test_get_settings_from_entry_points(self):
+        from ..utils import get_settings_from_entry_points
+
+        testing.install_test_packages()
+
+        contexts = testing.test_packages
+        settings = {
+            'db_connection_string': testing.db_connection_string,
+            }
+
+        get_settings_from_entry_points(settings, contexts)
+
+        self.assertEqual(
+            settings,
+            {'migrations_directory': testing.test_migrations_directories,
+             'db_connection_string': testing.db_connection_string,
+             })

--- a/dbmigrator/tests/test_utils.py
+++ b/dbmigrator/tests/test_utils.py
@@ -6,8 +6,13 @@
 # See LICENCE.txt for details.
 # ###
 
+import datetime
 import os.path
 import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import psycopg2
 
@@ -203,3 +208,12 @@ CREATE TABLE schema_migrations (
             stdout, 'Rolling back migration {} {}\n'.format(version, name))
 
         self.assertIn((version, name), after_migrations)
+
+    def test_timestamp(self):
+        from ..utils import timestamp
+
+        now = datetime.datetime(2016, 2, 28, 22, 51, 56)
+
+        with mock.patch('datetime.datetime') as mock_datetime:
+            mock_datetime.utcnow.return_value = now
+            self.assertEqual(timestamp(), '20160228225156')

--- a/dbmigrator/tests/testing.py
+++ b/dbmigrator/tests/testing.py
@@ -8,7 +8,20 @@
 
 from contextlib import contextmanager
 from io import StringIO
+import os.path
 import sys
+
+import pip
+
+
+here = os.path.abspath(os.path.dirname(__file__))
+db_connection_string = 'dbname=travis user=travis host=localhost'
+test_data_path = os.path.join(here, 'data')
+test_packages = ['package-a', 'package-b']
+test_migrations_directories = [
+    os.path.join(test_data_path, 'package-a', 'package_a', 'migrations'),
+    os.path.join(test_data_path, 'package-b', 'package_b', 'm'),
+    ]
 
 
 # noqa from http://stackoverflow.com/questions/4219717/how-to-assert-output-with-nosetest-unittest-in-python
@@ -25,3 +38,10 @@ def captured_output():
         yield sys.stdout, sys.stderr
     finally:
         sys.stdout, sys.stderr = old_out, old_err
+
+
+def install_test_packages(packages=None):
+    if packages is None:
+        packages = test_packages
+    for package in packages:
+        pip.main(['install', '-e', os.path.join(test_data_path, package)])

--- a/dbmigrator/tests/testing.py
+++ b/dbmigrator/tests/testing.py
@@ -18,6 +18,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 db_connection_string = 'dbname=travis user=travis host=localhost'
 test_data_path = os.path.join(here, 'data')
 test_packages = ['package-a', 'package-b']
+test_config_path = os.path.join(test_data_path, 'config.ini')
 test_migrations_directories = [
     os.path.join(test_data_path, 'package-a', 'package_a', 'migrations'),
     os.path.join(test_data_path, 'package-b', 'package_b', 'm'),

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ install_requires = (
 tests_require = [
     ]
 
+if sys.version_info.major < 3:
+    tests_require.append('mock')
+
 LONG_DESC = '\n\n~~~~\n\n'.join([open('README.rst').read(),
                                  open('CHANGELOG.rst').read()])
 


### PR DESCRIPTION
 - Add pep8 to travis
 - Add integration tests with test packages
 - Add test for utils.get_settings_from_config
 - Add test for utils.with_cursor
 - Fix `dbmigrator generate` migrations directory lookup

  ```
Traceback (most recent call last):
  File "./bin/dbmigrator", line 9, in <module>
    load_entry_point('db-migrator==0.1.1', 'console_scripts', 'dbmigrator')()
  File "/home/karen/db-migrator/dbmigrator/cli.py", line 86, in main
    return args['cmmd'](**args)
  File "/home/karen/db-migrator/dbmigrator/commands/generate.py", line 25, in cli_comm
    path = os.path.join(directory, filename)
  File "/home/karen/db-migrator/lib/python3.4/posixpath.py", line 82, in join
    elif not path or path.endswith(sep):
AttributeError: 'list' object has no attribute 'endswith'
```

 - Make `dbmigrator generate` generate pep8 compliant code
 - Add test for utils.import_migration
 - Add test for utils.get_migrations
 - Add test for utils.get_pending_migrations
 - Add test for utils.run_migration
 - Add test for utils.rollback_migration
 - Add test for utils.timestamp