### PR TITLE
Change `dbmigrator list` to list version and migration name separately

### DIFF
--- a/dbmigrator/commands/list.py
+++ b/dbmigrator/commands/list.py
@@ -20,11 +20,12 @@ def cli_command(cursor, migrations_directory='', db_connection_string='',
                                   raise_error=False)))
     migrations = utils.get_migrations(migrations_directory)
 
-    print('{:<25} | is applied | date applied'.format('name'))
+    print('version        | {:<15} | is applied | date applied'
+          .format('name'))
     print('-' * 70)
     for version, migration_name in migrations:
-        print('{: <25}   {!s: <10}   {}'.format(
-            '_'.join([version, migration_name])[:25],
+        print('{}   {: <15}   {!s: <10}   {}'.format(
+            version, migration_name[:15],
             bool(version in migrated_versions),
             migrated_versions.get(version, '')))
 

--- a/dbmigrator/tests/test_cli.py
+++ b/dbmigrator/tests/test_cli.py
@@ -76,7 +76,7 @@ class ListTestCase(BaseTestCase):
         stderr = err.getvalue()
 
         self.assertEqual(stdout, """\
-name                      | is applied | date applied
+version        | name            | is applied | date applied
 ----------------------------------------------------------------------\n""")
         self.assertEqual(stderr, """\
 context undefined, using current directory name "['db-migrator']"
@@ -92,7 +92,7 @@ migrations directory undefined\n""")
         stderr = err.getvalue()
 
         self.assertEqual("""\
-name                      | is applied | date applied
+version        | name            | is applied | date applied
 ----------------------------------------------------------------------\n""",
                          stdout)
 
@@ -112,11 +112,11 @@ name                      | is applied | date applied
         stderr = err.getvalue()
 
         self.assertEqual("""\
-name                      | is applied | date applied
+version        | name            | is applied | date applied
 ----------------------------------------------------------------------
-20160228202637_add_table    False        \
+20160228202637   add_table         False        \
 
-20160228212456_cool_stuff   False        \
+20160228212456   cool_stuff        False        \
 \n""", stdout)
         self.assertEqual('', stderr)
 
@@ -134,9 +134,9 @@ class InitTestCase(BaseTestCase):
                                'package-b', 'list'])
 
         stdout = out.getvalue()
-        self.assertIn('20160228202637_add_table    True', stdout)
-        self.assertIn('20160228210326_initial_da   True', stdout)
-        self.assertIn('20160228212456_cool_stuff   True', stdout)
+        self.assertIn('20160228202637   add_table         True', stdout)
+        self.assertIn('20160228210326   initial_data      True', stdout)
+        self.assertIn('20160228212456   cool_stuff        True', stdout)
 
 
 class MarkTestCase(BaseTestCase):
@@ -169,8 +169,8 @@ class MarkTestCase(BaseTestCase):
             self.target(cmd + ['--context', 'package-a', 'list'])
 
         stdout = out.getvalue()
-        self.assertIn('20160228202637_add_table    False', stdout)
-        self.assertIn('20160228212456_cool_stuff   True', stdout)
+        self.assertIn('20160228202637   add_table         False', stdout)
+        self.assertIn('20160228212456   cool_stuff        True', stdout)
 
     def test_mark_as_true_already_true(self):
         testing.install_test_packages()
@@ -190,8 +190,8 @@ class MarkTestCase(BaseTestCase):
             self.target(cmd + ['--context', 'package-a', 'list'])
 
         stdout = out.getvalue()
-        self.assertIn('20160228202637_add_table    True', stdout)
-        self.assertIn('20160228212456_cool_stuff   True', stdout)
+        self.assertIn('20160228202637   add_table         True', stdout)
+        self.assertIn('20160228212456   cool_stuff        True', stdout)
 
     @mock.patch('dbmigrator.logger.warning')
     def test_migration_not_found(self, warning):
@@ -223,8 +223,8 @@ class MarkTestCase(BaseTestCase):
             self.target(cmd + ['--context', 'package-a', 'list'])
 
         stdout = out.getvalue()
-        self.assertIn('20160228202637_add_table    False', stdout)
-        self.assertIn('20160228212456_cool_stuff   True', stdout)
+        self.assertIn('20160228202637   add_table         False', stdout)
+        self.assertIn('20160228212456   cool_stuff        True', stdout)
 
     def test_mark_as_false_already_false(self):
         testing.install_test_packages()
@@ -244,5 +244,5 @@ class MarkTestCase(BaseTestCase):
             self.target(cmd + ['--context', 'package-a', 'list'])
 
         stdout = out.getvalue()
-        self.assertIn('20160228202637_add_table    False', stdout)
-        self.assertIn('20160228212456_cool_stuff   False', stdout)
+        self.assertIn('20160228202637   add_table         False', stdout)
+        self.assertIn('20160228212456   cool_stuff        False', stdout)


### PR DESCRIPTION
Change from:

```
karen@trusty:~/db-migrator (master)$ ./bin/dbmigrator
--config=../cnx-archive/development.ini
--migrations-directory=../cnx-archive/cnxarchive/sql/migrations/ list
name                      | is applied | date applied
----------------------------------------------------------------------
20160101000000_update_fil   True         2016-04-18 23:26:28.835506+01:00
20160128110515_mimetype_o   True         2016-04-18 23:27:05.018055+01:00
20160128111115_mimetype_r   True         2016-04-18 23:26:28.835506+01:00
20160308064742_unique_fil   True         2016-04-18 23:26:28.835506+01:00
20160309072525_collation_   True         2016-04-18 23:26:28.835506+01:00
20160314200432_remove_xml   True         2016-04-18 23:26:28.835506+01:00
20160423022147_add_python   False
```

to:

```
karen@trusty:~/db-migrator (list)$ ./bin/dbmigrator --config=../cnx-archive/development.ini --migrations-directory=../cnx-archive/cnxarchive/sql/migrations/ list
version        | name            | is applied | date applied
----------------------------------------------------------------------
20160101000000   update_file_tri   True         2016-04-18 23:26:28.835506+01:00
20160128110515   mimetype_on_fil   True         2016-04-18 23:27:05.018055+01:00
20160128111115   mimetype_remova   True         2016-04-18 23:26:28.835506+01:00
20160308064742   unique_files_by   True         2016-04-18 23:26:28.835506+01:00
20160309072525   collation_schem   True         2016-04-18 23:26:28.835506+01:00
20160314200432   remove_xml_from   True         2016-04-18 23:26:28.835506+01:00
20160423022147   add_python_sql_   False
```