### PR TITLE
Add repeat conditional migrations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -217,6 +217,17 @@ To write a repeat migration, make sure your migration has ``should_run`` defined
 The above migration will run **every time** ``migrate`` is called, except if it
 is marked as "deferred".  ``up`` is run if ``should_run`` returns True.
 
+To write a deferred migration, add ``@deferred`` to the up function::
+
+    from dbmigrator import deferred
+
+
+    @deferred
+    def up(cursor):
+        # this migration is automatically deferred
+
+The above migration will not run unless you use ``migrate --run-deferred``.
+
 rollback
 --------
 

--- a/README.rst
+++ b/README.rst
@@ -69,9 +69,15 @@ Example usage::
 generates a file called ``migrations/20151217170514_add_id_to_users.py``
 with content::
 
+    # Uncomment should_run if this is a repeat migration
+    # def should_run(cursor):
+    #     # TODO return True if migration should run
+
+
     def up(cursor):
         # TODO migration code
         pass
+
 
     def down(cursor):
         # TODO rollback code
@@ -192,6 +198,24 @@ if all migrations have already been run::
 
     $ dbmigrator migrate
     No pending migrations.  Database is up to date.
+
+To write a repeat migration, make sure your migration has ``should_run`` defined::
+
+    def should_run(cursor):
+        return os.path.exists('data.txt')
+
+
+    def up(cursor):
+        with open('data.txt') as f:
+            data = f.read()
+        cursor.execute('INSERT INTO table VALUES (%s)', (data,))
+
+
+    def down(cursor):
+        pass
+
+The above migration will run **every time** ``migrate`` is called, except if it
+is marked as "deferred".  ``up`` is run if ``should_run`` returns True.
 
 rollback
 --------

--- a/README.rst
+++ b/README.rst
@@ -112,8 +112,11 @@ Example usage::
     version        | name            | is applied | date applied
     ----------------------------------------------------------------------
     20151217170514   add_id_to_users   True         2016-01-31 00:15:01.692570+01:00
-    20151218145832   add_karen_to_us   False               
-    20160107200351   blah              False               
+    20151218145832   add_karen_to_us   False*              
+    20160107200351   blah              deferred            
+
+A `*` in the "is applied" column means that the migration is a repeated
+migration.
 
 To see the full migration name, use ``--wide``::
 
@@ -121,8 +124,8 @@ To see the full migration name, use ``--wide``::
     version        | name               | is applied | date applied
     ----------------------------------------------------------------------
     20151217170514   add_id_to_users      True         2016-01-31 00:15:01.692570+01:00
-    20151218145832   add_karen_to_users   False               
-    20160107200351   blah                 False               
+    20151218145832   add_karen_to_users   False*              
+    20160107200351   blah                 deferred            
 
 
 migrate

--- a/dbmigrator/__init__.py
+++ b/dbmigrator/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from .utils import logger, super_user
+from .utils import logger, super_user, deferred
 
 
-__all__ = ('logger', 'super_user')
+__all__ = ('logger', 'super_user', 'deferred')

--- a/dbmigrator/commands/generate.py
+++ b/dbmigrator/commands/generate.py
@@ -31,6 +31,11 @@ def cli_command(migration_name='', **kwargs):
 # -*- coding: utf-8 -*-
 
 
+# Uncomment should_run if this is a repeat migration
+# def should_run(cursor):
+#     # TODO return True if migration should run
+
+
 def up(cursor):
     # TODO migration code
     pass

--- a/dbmigrator/commands/list.py
+++ b/dbmigrator/commands/list.py
@@ -42,6 +42,8 @@ def cli_command(cursor, migrations_directory='', db_connection_string='',
             version, migration, migrated_versions)
         is_applied = deferred and 'deferred' or \
             bool(migrated_versions.get(version))
+        if hasattr(migration, 'should_run'):
+            is_applied = '{}*'.format(is_applied)
         print('{}   {}   {!s: <10}   {}'.format(
             version, name_format.format(migration_name[:name_width]),
             is_applied, migrated_versions.get(version) or ''))

--- a/dbmigrator/commands/mark.py
+++ b/dbmigrator/commands/mark.py
@@ -19,20 +19,18 @@ def cli_command(cursor, migrations_directory='', migration_timestamp='',
     if completed is None:
         raise Exception('-t, -f or -d must be supplied.')
 
-    migrations = utils.get_migrations(
-        migrations_directory, import_modules=False)
-    for version, _ in migrations:
-        if version == migration_timestamp:
-            break
-    else:
-        migrated_versions = list(utils.get_schema_versions(cursor))
-        if migration_timestamp not in migrated_versions:
-            logger.warning(
-                'Migration {} not found'.format(migration_timestamp))
+    migrations = {version: migration
+                  for version, _, migration in utils.get_migrations(
+                      migrations_directory, import_modules=True)}
+    migration = migrations.get(migration_timestamp)
+    if migration is None:
+        logger.error(
+            'Migration {} not found'.format(migration_timestamp))
+        return
 
     utils.mark_migration(cursor, migration_timestamp, completed)
     if not completed:
-        message = 'not been run'
+        message = 'not been run and not deferred'
     elif completed == 'deferred':
         message = 'deferred'
     else:

--- a/dbmigrator/commands/mark.py
+++ b/dbmigrator/commands/mark.py
@@ -24,9 +24,8 @@ def cli_command(cursor, migrations_directory='', migration_timestamp='',
                       migrations_directory, import_modules=True)}
     migration = migrations.get(migration_timestamp)
     if migration is None:
-        logger.error(
+        raise SystemExit(
             'Migration {} not found'.format(migration_timestamp))
-        return
 
     utils.mark_migration(cursor, migration_timestamp, completed)
     if not completed:

--- a/dbmigrator/commands/migrate.py
+++ b/dbmigrator/commands/migrate.py
@@ -15,10 +15,10 @@ __all__ = ('cli_loader',)
 
 @utils.with_cursor
 def cli_command(cursor, migrations_directory='', version='',
-                db_connection_string='', **kwargs):
+                db_connection_string='', run_deferred=False, **kwargs):
     pending_migrations = utils.get_pending_migrations(
         migrations_directory, cursor, import_modules=True,
-        up_to_version=version)
+        up_to_version=version, include_defers=True)
 
     migrated = False
     for version, migration_name, migration in pending_migrations:
@@ -28,7 +28,8 @@ def cli_command(cursor, migrations_directory='', version='',
                              cursor,
                              version,
                              migration_name,
-                             migration)
+                             migration,
+                             run_deferred)
 
     if not migrated:
         print('No pending migrations.  Database is up to date.')
@@ -37,4 +38,7 @@ def cli_command(cursor, migrations_directory='', version='',
 def cli_loader(parser):
     parser.add_argument('--version',
                         help='Migrate database up to this version')
+    parser.add_argument('--run-deferred',
+                        action='store_true',
+                        help='Also run the deferred migrations')
     return cli_command

--- a/dbmigrator/commands/rollback.py
+++ b/dbmigrator/commands/rollback.py
@@ -7,7 +7,7 @@
 # ###
 """Rollback a migration."""
 
-from .. import utils
+from .. import logger, utils
 
 
 __all__ = ('cli_loader',)
@@ -18,7 +18,7 @@ def cli_command(cursor, migrations_directory='', steps=1,
                 db_connection_string='', **kwargs):
     migrated_versions = list(utils.get_schema_versions(
         cursor, include_deferred=False))
-    print('migrated_versions: {}'.format(migrated_versions))
+    logger.debug('migrated_versions: {}'.format(migrated_versions))
     if not migrated_versions:
         print('No migrations to roll back.')
         return

--- a/dbmigrator/tests/data/md/20170810093842_create_a_table.py
+++ b/dbmigrator/tests/data/md/20170810093842_create_a_table.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+
+# Uncomment should_run if this is a repeat migration
+# def should_run(cursor):
+#     # TODO return True if migration should run
+
+
+def up(cursor):
+    cursor.execute('CREATE TABLE a_table (name TEXT)')
+
+
+def down(cursor):
+    cursor.execute('DROP TABLE a_table')

--- a/dbmigrator/tests/data/md/20170810093943_repeat_insert_data.py
+++ b/dbmigrator/tests/data/md/20170810093943_repeat_insert_data.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+
+def should_run(cursor):
+    return os.path.exists('insert_data.txt')
+
+
+def up(cursor):
+    with open('insert_data.txt') as f:
+        data = f.read()
+    cursor.execute('INSERT INTO a_table VALUES (%s)', (data,))
+
+
+def down(cursor):
+    with open('insert_data.txt') as f:
+        data = f.read()
+    cursor.execute('DELETE FROM a_table WHERE name = %s', (data,))

--- a/dbmigrator/tests/data/md/20170810124056_empty.py
+++ b/dbmigrator/tests/data/md/20170810124056_empty.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 
+from dbmigrator import deferred
+
 
 # Uncomment should_run if this is a repeat migration
-# def should_run(cursor):
-#     # TODO return True if migration should run
+def should_run(cursor):
+    # TODO return True if migration should run
+    return True
 
 
+@deferred
 def up(cursor):
     # TODO migration code
     pass

--- a/dbmigrator/tests/data/md/20170810124056_empty.py
+++ b/dbmigrator/tests/data/md/20170810124056_empty.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+
+# Uncomment should_run if this is a repeat migration
+# def should_run(cursor):
+#     # TODO return True if migration should run
+
+
+def up(cursor):
+    # TODO migration code
+    pass
+
+
+def down(cursor):
+    # TODO rollback code
+    pass

--- a/dbmigrator/tests/test_cli.py
+++ b/dbmigrator/tests/test_cli.py
@@ -353,7 +353,7 @@ SELECT 1 FROM information_schema.tables
             self.target(cmd + ['list'])
 
         stdout = out.getvalue()
-        self.assertIn('20170810124056   empty             deferred     20',
+        self.assertIn('20170810124056   empty             deferred*    20',
                       stdout)
 
         # mark a deferred migration as not not been run
@@ -679,7 +679,13 @@ SELECT table_name FROM information_schema.tables
         with testing.captured_output() as (out, err):
             self.target(cmd + ['migrate'])
 
-        self.target(cmd + ['list'])
+        with testing.captured_output() as (out, err):
+            self.target(cmd + ['list'])
+
+        stdout = out.getvalue()
+        self.assertIn('20170810093842   create_a_table    True ', stdout)
+        self.assertIn('20170810093943   repeat_insert_d   True*', stdout)
+        self.assertIn('20170810124056   empty             deferred*', stdout)
 
         # Version wise, the empty migration is more recent, but the repeat
         # migration is the last migration applied, so rollback should rollback

--- a/dbmigrator/tests/test_cli.py
+++ b/dbmigrator/tests/test_cli.py
@@ -217,18 +217,19 @@ class MarkTestCase(BaseTestCase):
         self.assertIn('20160228202637   add_table         True', stdout)
         self.assertIn('20160228212456   cool_stuff        True', stdout)
 
-    @mock.patch('dbmigrator.logger.error')
-    def test_migration_not_found(self, error):
+    def test_migration_not_found(self):
         testing.install_test_packages()
         cmd = ['--db-connection-string', testing.db_connection_string]
 
         self.target(cmd + ['--context', 'package-a', 'init', '--version', '0'])
 
-        self.target(cmd + ['mark', '-t', '012345'])
-        error.assert_called_with('Migration 012345 not found')
+        with self.assertRaises(SystemExit) as cm:
+            self.target(cmd + ['mark', '-t', '012345'])
+        self.assertEqual('Migration 012345 not found', str(cm.exception))
 
-        self.target(cmd + ['mark', '-f', '012345'])
-        error.assert_called_with('Migration 012345 not found')
+        with self.assertRaises(SystemExit) as cm:
+            self.target(cmd + ['mark', '-f', '012345'])
+        self.assertEqual('Migration 012345 not found', str(cm.exception))
 
     def test_mark_as_false(self):
         testing.install_test_packages()

--- a/dbmigrator/tests/testing.py
+++ b/dbmigrator/tests/testing.py
@@ -45,4 +45,7 @@ def install_test_packages(packages=None):
     if packages is None:
         packages = test_packages
     for package in packages:
-        pip.main(['install', '-e', os.path.join(test_data_path, package)])
+        with captured_output() as (out, err):
+            pip.main(['install', '-e', os.path.join(test_data_path, package)])
+        stderr = err.getvalue()
+        sys.stderr.write(stderr)

--- a/dbmigrator/utils.py
+++ b/dbmigrator/utils.py
@@ -212,7 +212,7 @@ def compare_schema(db_connection_string, callback, *args, **kwargs):
     print(''.join(list(
         difflib.unified_diff(old_schema.splitlines(True),
                              new_schema.splitlines(True),
-                             n=10))))
+                             n=10))).encode('utf-8'))
 
 
 def run_migration(cursor, version, migration_name, migration):


### PR DESCRIPTION
If the migration file has `should_run` defined, it is considered a
repeat migration.  `should_run` is called every time `migrate` is run,
and if it returns true, `up` is run.

Close Connexions/db-migrator#1