### PR TITLE
Fix python3 schema diff to output as str

### DIFF
--- a/dbmigrator/utils.py
+++ b/dbmigrator/utils.py
@@ -230,7 +230,7 @@ def compare_schema(db_connection_string, callback, *args, **kwargs):
     print(''.join(list(
         difflib.unified_diff(old_schema.splitlines(True),
                              new_schema.splitlines(True),
-                             n=10))).encode('utf-8'))
+                             n=10))).encode('utf-8').decode('utf-8'))
 
 
 def run_migration(cursor, version, migration_name, migration,


### PR DESCRIPTION
When running migrations in python3, the schema diff is displayed:

```
Running migration 20170810093842 create_a_table
b"--- \n+++ \n@@ -38,20 +38,31 @@\n $$;\n \n \n ALTER FUNCTION public.karen_trigger() OWNER TO travis;\n \n SET default_tablespace = '';\n \n SET default_with_oids = false;\n \n --\n+-- Name: a_table; Type: TABLE; Schema: public; Owner: travis; Tablespace: \n+--\n+\n+CREATE TABLE a_table (\n+    name text\n+);\n+\n+\n+ALTER TABLE a_table OWNER TO travis;\n+\n+--\n -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: travis; Tablespace: \n --\n \n CREATE TABLE schema_migrations (\n     version text NOT NULL,\n     applied timestamp with time zone DEFAULT now()\n );\n \n \n ALTER TABLE schema_migrations OWNER TO travis;\n"
```

`str` and `byte` are mixed together causing the output to be hard to read.

Change schema diff to display as `str`.