### PR TITLE
handle empty migration list case for wide listing

### DIFF
--- a/dbmigrator/commands/list.py
+++ b/dbmigrator/commands/list.py
@@ -24,11 +24,17 @@ def cli_command(cursor, migrations_directory='', db_connection_string='',
     migrations = utils.get_migrations(migrations_directory,
                                       import_modules=True)
 
+    name_width = 15
+
     if wide:
         migrations = list(migrations)
-        name_width = max([len(name) for _, name, _ in migrations])
-    else:
-        name_width = 15
+        try:
+            name_width = max([len(name) for _, name, _ in migrations])
+        except ValueError:
+            if migrations == []:
+                pass
+            else:
+                raise
 
     name_format = '{:<%s}' % (name_width,)
     print('version        | {} | is applied | date applied'


### PR DESCRIPTION
Hit this traceback recently:
```
Traceback (most recent call last):
  File "/home/reedstrm/src/rewrite/bin/dbmigrator", line 11, in <module>
    load_entry_point('db-migrator', 'console_scripts', 'dbmigrator')()
  File "/home/reedstrm/src/rewrite/db-migrator/dbmigrator/cli.py", line 116, in main
    return args['cmmd'](**args)
  File "/home/reedstrm/src/rewrite/db-migrator/dbmigrator/utils.py", line 155, in wrapper
    return func(cursor, *args, **kwargs)
  File "/home/reedstrm/src/rewrite/db-migrator/dbmigrator/commands/list.py", line 29, in cli_command
    name_width = max([len(name) for _, name, _ in migrations])
ValueError: max() arg is an empty sequence
```
This code solves it.